### PR TITLE
Added new branches and scale+smearing corrections in skim_processor.py and skim_config.py

### DIFF
--- a/skimming/skim_config.py
+++ b/skimming/skim_config.py
@@ -1,8 +1,10 @@
 
 branches_to_keep = {
             "Muon": ["pt", "eta", "phi","charge","pdgId","tightId","mass","pfRelIso03_all","pfRelIso04_all"],                                                                                       
-            "Electron": ["pt", "eta", "phi","charge","pdgId","cutBased","mass","pfRelIso03_all","pfRelIso04_all"],                                                                                  
-            "Jet": ["pt", "eta", "phi","btagUParTAK4probbb","svIdx1","svIdx2","mass","btagDeepFlavB","btagUParTAK4B","passJetIdTight", "passJetIdTightLepVeto","pt_regressed","hadronFlavour","partonFlavour","pnet_resol"],
+            "Electron": ["pt", "eta", "phi","charge","pdgId","cutBased","mass","pfRelIso03_all","pfRelIso04_all",
+                         "seedGain","r9","superclusterEta","pt_raw","pt_smearUp", "pt_smearDown","pt_scaleUp","pt_scaleDown"],                                                                                  
+            "Jet": ["pt", "eta", "phi","btagUParTAK4probbb","svIdx1","svIdx2","mass","btagDeepFlavB","btagUParTAK4B","passJetIdTight", 
+                    "passJetIdTightLepVeto","pt_regressed","hadronFlavour","partonFlavour","pnet_resol"],
             "PFMET": ["pt", "phi","sumEt"],
             "PuppiMET": ["pt", "phi","sumEt"],
             "Pileup":["nTrueInt","nPU"],
@@ -19,8 +21,8 @@ trigger_groups = {
     2: ["IsoMu24"],
     3: ["Mu50"],
     4: ["Ele23_Ele12_CaloIdL_TrackIdL_IsoVL","DoubleEle25_CaloIdL_MW"],
-    5: ["Ele32_WPTight_Gsf"],
-    6: ["Ele35_WPTight_Gsf"],
+    5: ["Ele30_WPTight_Gsf"],
+    6: ["Ele32_WPTight_Gsf"],
     7: ["Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ", "Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL", "Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ"],
     8: ["PFMET120_PFMHT120_IDTight","PFMET120_PFMHT120_IDTight_PFHT60"],
     9: ["QuadPFJet105_88_76_15_PFBTagDeepCSV_1p3_VBF2"],
@@ -40,5 +42,4 @@ trigger_groups = {
     23: ["QuadPFJet111_90_80_15_PNet2BTag_0p4_0p12_VBF1"],
     24: ["QuadPFJet111_90_80_15_PNetBTag_0p4_VBF2"],
     25: ["PFHT340_QuadPFJet70_50_40_40_PNet2BTagMean0p70"],
-   
 }


### PR DESCRIPTION
- skim_config.py :  Added branches for scale and smearing corrections ("seedGain", "r9", "superclusterEta") Added new branches ("pt_raw", "pt_smearUp", "pt_smearDown","pt_scaleUp", "pt_scaleDown")

-skim_processor.py:
Applied  energy scale corrections to data (usually, energies in data are shifted to the right since, on average, the measured energy is underestimated compared to MC). Applied smearing corrections to MC (the energies in MC are smeared out stochastically since the predicted resolution in MC is optimistic) Created the branches "pt_smearUp", "pt_smearDown" for smearing uncertainties in MC Created the branches "pt_scaleUp", "pt_scaleDown" for scaling uncertainties in MC.

Recommendations:https://twiki.cern.ch/twiki/bin/view/CMS/EgammSFandSSRun3#2022_2023_and_2024_Scale_and_Sme